### PR TITLE
feat: add support for alphanumeric CNPJ

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 /**
- * Validates a CNPJ
+ * Validates a CNPJ (numeric or alphanumeric)
  * @param cnpj The CNPJ value to be validated
  */
 export function validate(cnpj: string | number): boolean {
@@ -11,8 +11,10 @@ export function validate(cnpj: string | number): boolean {
 		!cleaned ||
 		// Must have 14 characters
 		cleaned.length !== 14 ||
-		// Must be digits and not be sequential characters (e.g.: 11111111111111, etc)
-		/^(\d)\1+$/.test(cleaned)
+		// First 12 must be digits or uppercase letters; last 2 must be digits
+		!/^[A-Z0-9]{12}\d{2}$/.test(cleaned) ||
+		// Must not be sequential identical characters (e.g.: 11111111111111, AAAAAAAAAAAAAA, etc)
+		/^(.)\1+$/.test(cleaned)
 	) {
 		return false
 	}
@@ -25,11 +27,22 @@ export function validate(cnpj: string | number): boolean {
 }
 
 /**
- * Formats a CNPJ value
+ * Formats a CNPJ value (numeric or alphanumeric)
  * @param cnpj The CNPJ to be formatted
  * @return The formatted CNPJ
  */
 export function format(cnpj: string | number): string {
+	// Strip only formatting characters (period, slash, dash)
+	const stripped = cnpj.toString().replace(/[\.\/\-]/g, '')
+
+	// If it looks like a well-formed alphanumeric CNPJ, format preserving letters
+	if (/^[A-Z0-9]{12}\d{2}$/.test(stripped)) {
+		return stripped.replace(
+			/^([A-Z0-9]{2})([A-Z0-9]{3})([A-Z0-9]{3})([A-Z0-9]{4})(\d{2})$/,
+			'$1.$2.$3/$4-$5',
+		)
+	}
+
 	return (
 		cnpj
 			.toString()
@@ -40,16 +53,34 @@ export function format(cnpj: string | number): string {
 	)
 }
 
+export interface GenerateOptions {
+	/**
+	 * The format of the generated CNPJ.
+	 * - `"numeric"` (default): 12 digits + 2 numeric verification digits.
+	 * - `"alphanumeric"`: 12 alphanumeric characters (uppercase `A`-`Z` and
+	 *   digits) + 2 numeric verification digits.
+	 */
+	format?: 'numeric' | 'alphanumeric'
+}
+
 /**
  * Generates a valid CNPJ
+ * @param options Optional generation settings
  * @return The generated CNPJ
  */
-export function generate(): string {
+export function generate(options: GenerateOptions = {}): string {
+	const { format: outputFormat = 'numeric' } = options
+
+	const alphabet =
+		outputFormat === 'alphanumeric'
+			? '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+			: '0123456789'
+
 	let cnpj = ''
 	let i = 12
 
 	while (i--) {
-		cnpj += Math.floor(Math.random() * 9)
+		cnpj += alphabet[Math.floor(Math.random() * alphabet.length)]
 	}
 
 	cnpj += digit(cnpj)
@@ -58,11 +89,14 @@ export function generate(): string {
 	return format(cnpj)
 }
 
-function digit(numbers: string): number {
+function digit(characters: string): number {
 	let index = 2
 
-	const sum = [...numbers].reverse().reduce((buffer, number) => {
-		buffer += Number(number) * index
+	const sum = [...characters].reverse().reduce((buffer, char) => {
+		// Per the alphanumeric CNPJ spec, the value is the ASCII code minus 48.
+		// For digits '0'-'9' this equals 0-9 (matching the previous numeric behavior).
+		// For uppercase 'A'-'Z' (ASCII 65-90) this yields 17-42.
+		buffer += (char.charCodeAt(0) - 48) * index
 		index = index === 9 ? 2 : index + 1
 		return buffer
 	}, 0)

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # CNPJ
 
-Format, validate and generate CNPJ numbers.
+Format, validate and generate CNPJ numbers. Supports both numeric and the alphanumeric formats.
 
 ## Installation
 
@@ -35,12 +35,15 @@ import { validate, format, generate } from '@brazil/cnpj';
 ```js
 // Validation
 const valid = validate('38.981.218/0001-47'); // true
+const validAlphanumeric = validate('12.ABC.345/01DE-35'); // true
 
 // Format
-const formatted = format(88415345000157) // 88.415.345/0001-57
+const formatted = format(88415345000157); // 88.415.345/0001-57
+const formattedAlphanumeric = format('12ABC34501DE35'); // '12.ABC.345/01DE-35'
 
 // Generation
 const generated = generate(); // randomly generated, valid CNPJ
+const generatedAlphanumeric = generate({ format: 'alphanumeric' }); // randomly generated, valid alphanumeric CNPJ
 ```
 
 ### License

--- a/test.ts
+++ b/test.ts
@@ -50,3 +50,56 @@ test('generate CNPJ', () => {
 	assert.equal(validate(generate()), true)
 	assert.equal(/^\d{2}\.\d{3}\.\d{3}\/\d{4}\-\d{2}$/.test(generate()), true)
 })
+
+test('valid alphanumeric formatted CNPJs', () => {
+	// Example from the SERPRO specification
+	assert.equal(validate('12.ABC.345/01DE-35'), true)
+})
+
+test('valid alphanumeric unformatted CNPJs', () => {
+	assert.equal(validate('12ABC34501DE35'), true)
+})
+
+test('invalid alphanumeric CNPJs (wrong DV)', () => {
+	assert.equal(validate('12.ABC.345/01DE-00'), false)
+	assert.equal(validate('12ABC34501DE99'), false)
+})
+
+test('invalid alphanumeric CNPJs (lowercase letters not accepted)', () => {
+	assert.equal(validate('12.abc.345/01de-35'), false)
+	assert.equal(validate('12abc34501de35'), false)
+})
+
+test('invalid alphanumeric CNPJs (DV section must be numeric)', () => {
+	// Letters are not allowed in the last two (DV) positions
+	assert.equal(validate('12.ABC.345/01DE-3A'), false)
+	assert.equal(validate('12ABC34501DEAB'), false)
+})
+
+test('invalid sequential alphanumeric CNPJs', () => {
+	assert.equal(validate('AAAAAAAAAAAAAA'), false)
+	assert.equal(validate('ZZZZZZZZZZZZZZ'), false)
+})
+
+test('format alphanumeric CNPJ preserving letters', () => {
+	assert.equal(format('12ABC34501DE35'), '12.ABC.345/01DE-35')
+	// Already-formatted alphanumeric CNPJ remains correctly formatted
+	assert.equal(format('12.ABC.345/01DE-35'), '12.ABC.345/01DE-35')
+})
+
+test('generate numeric CNPJ explicitly', () => {
+	const cnpj = generate({ format: 'numeric' })
+	assert.equal(validate(cnpj), true)
+	assert.equal(/^\d{2}\.\d{3}\.\d{3}\/\d{4}\-\d{2}$/.test(cnpj), true)
+})
+
+test('generate alphanumeric CNPJ', () => {
+	for (let i = 0; i < 50; i++) {
+		const cnpj = generate({ format: 'alphanumeric' })
+		assert.equal(validate(cnpj), true)
+		assert.equal(
+			/^[A-Z0-9]{2}\.[A-Z0-9]{3}\.[A-Z0-9]{3}\/[A-Z0-9]{4}\-\d{2}$/.test(cnpj),
+			true,
+		)
+	}
+})


### PR DESCRIPTION
Implements support for the new alphanumeric CNPJ format being introduced in July 2026 by Brazil's Federal Revenue Service, while maintaining full backward compatibility with numeric CNPJs.

Closes https://github.com/gabeins/cnpj/issues/33.